### PR TITLE
Update default compile_commands.json path

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
             "properties": {
                 "iwyu.compile_commands": {
                     "type": "string",
-                    "default": "${workspaceFolder}/compile_commands.json",
+                    "default": "${workspaceFolder}/build/compile_commands.json",
                     "markdownDescription": "Path to `compile_commands.json` file (supports `${workspaceFolder}` and `${workspaceRoot}`)."
                 },
                 "iwyu.filter_iwyu_output": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -287,7 +287,7 @@ class ConfigData {
 
     compileCommandsJson(): string {
         return this.config
-            .get("compile_commands", "${workspaceFolder}/XXX/compile_commands.json")
+            .get("compile_commands", "${workspaceFolder}/build/compile_commands.json")
             .replace("${workspaceRoot}", this.workspacefolder)
             .replace("${workspaceFolder}", this.workspacefolder);
     }


### PR DESCRIPTION
This default `compile_commands.json` path reflects the default from the popular `CMake Tools` extension and is probably appropriate for >90% of all configurations.