### PR TITLE
Fix README

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ easily achievable with all projects. The standard clang configurations also have
 
 This extension has the following general settings:
 
-- `iwyu.compile_commands.json` Path to `compile_commands.json` file (supports `${workspaceFolder}` and
+- `iwyu.compile_commands` Path to `compile_commands.json` file (supports `${workspaceFolder}` and
   `${workspaceRoot}`).
 - `iwyu.filter_iwu_output`: Regexp expression filter for iwyu output. This will be used as {here} in
   '#include.*({here})'. For instance in order to not add system includes under '__fwd/*.', set this to '<__fwd/'. This


### PR DESCRIPTION
Fix README for `iwyu.compile_commands` (as opposed to wrongly stated `iwyu.compile_commands.json`)

This should help with bugs like: https://github.com/helly25/vscode-iwyu/issues/3