### PR TITLE
Update default for iwyu.compile_commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 # [0.0.16]
 
-If the default for `iwyu.compile_commands` is unchanged, but the file is not found, then the extension will also try `${workspaceFolder}/build/compile_commands.json`.
+* If `iwyu.compile_commands` is set to the default `auto`, then the extension will try:
+  - `${workspaceFolder}/compile_commands.json`,
+  - `${workspaceFolder}/build/compile_commands.json`,
+  - `${fileWorkspaceFolder}/compile_commands.json`, and
+  - `${fileWorkspaceFolder}/build/compile_commands.json`.
 * Added rudimentary support for `${fileWorkspaceFolder}` in `iwyu.compile_commands` settings.
 
 # [0.0.15]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 # [0.0.16]
 
+If the default for `iwyu.compile_commands` is unchanged, but the file is not found, then the extension will also try `${workspaceFolder}/build/compile_commands.json`.
 * Added rudimentary support for `${fileWorkspaceFolder}` in `iwyu.compile_commands` settings.
 
 # [0.0.15]

--- a/README.md
+++ b/README.md
@@ -53,8 +53,12 @@ easily achievable with all projects. The standard clang configurations also have
 
 This extension has the following general settings:
 
-- `iwyu.compile_commands` Path to `compile_commands.json` file (supports `${workspaceFolder}` and
-  `${workspaceRoot}`).
+- `iwyu.compile_commands` Path to `compile_commands.json` file (supports `${workspaceFolder}`,
+  `${workspaceRoot}` and `${fileWorkspaceFolder}`). If set to the default `auto`, then the extension will try:
+  - `${workspaceFolder}/compile_commands.json`,
+  - `${workspaceFolder}/build/compile_commands.json`,
+  - `${fileWorkspaceFolder}/compile_commands.json`, and
+  - `${fileWorkspaceFolder}/build/compile_commands.json`.
 - `iwyu.filter_iwu_output`: Regexp expression filter for iwyu output. This will be used as {here} in
   '#include.*({here})'. For instance in order to not add system includes under '__fwd/*.', set this to '<__fwd/'. This
   does not result in removing such headers, it merely prevents adding them, so it won't produce diagnostics for such includes.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,17 @@
 {
     "name": "helly25iwyu",
-    "version": "0.0.1",
+    "version": "0.0.16",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "helly25iwyu",
-            "version": "0.0.1",
+            "version": "0.0.16",
             "license": "Apache-2.0",
             "devDependencies": {
                 "@types/glob": "^8.1.0",
                 "@types/mocha": "^10.0.1",
-                "@types/node": "16.x",
+                "@types/node": "^16.18.101",
                 "@types/vscode": "^1.78.0",
                 "@typescript-eslint/eslint-plugin": "^5.59.1",
                 "@typescript-eslint/parser": "^5.59.1",
@@ -187,9 +187,9 @@
             "dev": true
         },
         "node_modules/@types/node": {
-            "version": "16.18.34",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.34.tgz",
-            "integrity": "sha512-VmVm7gXwhkUimRfBwVI1CHhwp86jDWR04B5FGebMMyxV90SlCmFujwUHrxTD4oO+SOYU86SoxvhgeRQJY7iXFg==",
+            "version": "16.18.101",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.101.tgz",
+            "integrity": "sha512-AAsx9Rgz2IzG8KJ6tXd6ndNkVcu+GYB6U/SnFAaokSPNx2N7dcIIfnighYUNumvj6YS2q39Dejz5tT0NCV7CWA==",
             "dev": true
         },
         "node_modules/@types/semver": {

--- a/package.json
+++ b/package.json
@@ -41,8 +41,8 @@
             "properties": {
                 "iwyu.compile_commands": {
                     "type": "string",
-                    "default": "${workspaceFolder}/compile_commands.json",
-                    "markdownDescription": "Path to `compile_commands.json` file (supports `${workspaceFolder}` and `${workspaceRoot}`). If the default is unchanged, but the file is not found, then the extension will also try `${workspaceFolder}/build/compile_commands.json`."
+                    "default": "auto",
+                    "markdownDescription": "Path to `compile_commands.json` file (supports `${workspaceFolder}`, `${fileWorkspaceFolder}` and `${workspaceRoot}`). If this is set to the default `auto`, then the extension will try `${workspaceFolder}/compile_commands.json`, `${workspaceFolder}/build/compile_commands.json`, `${fileWorkspaceFolder}/compile_commands.json` and `${fileWorkspaceFolder}/build/compile_commands.json`."
                 },
                 "iwyu.filter_iwyu_output": {
                     "type": "string",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
         "Include What You Use",
         "include-what-you-use"
     ],
-    "version": "0.0.15",
+    "version": "0.0.16",
     "publisher": "helly25",
     "license": "Apache-2.0",
     "repository": {
@@ -42,7 +42,7 @@
                 "iwyu.compile_commands": {
                     "type": "string",
                     "default": "${workspaceFolder}/compile_commands.json",
-                    "markdownDescription": "Path to `compile_commands.json` file (supports `${workspaceFolder}` and `${workspaceRoot}`)."
+                    "markdownDescription": "Path to `compile_commands.json` file (supports `${workspaceFolder}` and `${workspaceRoot}`). If the default is unchanged, but the file is not found, then the extension will also try `${workspaceFolder}/build/compile_commands.json`."
                 },
                 "iwyu.filter_iwyu_output": {
                     "type": "string",
@@ -183,16 +183,16 @@
         "test": "node ./out/test/runTest.js"
     },
     "devDependencies": {
-        "@types/vscode": "^1.78.0",
         "@types/glob": "^8.1.0",
         "@types/mocha": "^10.0.1",
-        "@types/node": "16.x",
+        "@types/node": "^16.18.101",
+        "@types/vscode": "^1.78.0",
         "@typescript-eslint/eslint-plugin": "^5.59.1",
         "@typescript-eslint/parser": "^5.59.1",
+        "@vscode/test-electron": "^2.3.0",
         "eslint": "^8.39.0",
         "glob": "^8.1.0",
         "mocha": "^10.2.0",
-        "typescript": "^5.0.4",
-        "@vscode/test-electron": "^2.3.0"
+        "typescript": "^5.0.4"
     }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -297,7 +297,28 @@ class ConfigData {
     compileCommandsJson(): string {
         let compileCommandsJsonDefault = "${workspaceFolder}/compile_commands.json";
         let compileCommandsJson = this.config.get("compile_commands", compileCommandsJsonDefault);
-        return this.replaceWorkspaceVars(compileCommandsJson);
+        log(DEBUG, "Got compileCommandsJson = '" + compileCommandsJson + "'.");
+        let isDefault = compileCommandsJson === compileCommandsJsonDefault;
+        log(DEBUG, "IsDefault: " + isDefault);
+        compileCommandsJson = this.replaceWorkspaceVars(compileCommandsJson);
+        try {
+            fs.statSync(compileCommandsJson);
+            log(DEBUG, "Using compileCommandsJson = '" + compileCommandsJson + "'.");
+        }
+        catch (err) {
+            if (isDefault) {
+                try {
+                    let test = this.replaceWorkspaceVars("${workspaceFolder}/build/compile_commands.json");
+                    fs.statSync(test);
+                    compileCommandsJson = test;
+                    log(DEBUG, "Using alternative compileCommandsJson = '" + compileCommandsJson + "'.");
+                }
+                catch (err) {
+                    // Ignore, caught later.
+                }
+            }
+        }
+        return compileCommandsJson;
     }
 
     updateConfig() {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -297,13 +297,10 @@ class ConfigData {
     compileCommandsJson(): string {
         let compileCommandsJsonDefault = "${workspaceFolder}/compile_commands.json";
         let compileCommandsJson = this.config.get("compile_commands", compileCommandsJsonDefault);
-        log(DEBUG, "Got compileCommandsJson = '" + compileCommandsJson + "'.");
         let isDefault = compileCommandsJson === compileCommandsJsonDefault;
-        log(DEBUG, "IsDefault: " + isDefault);
         compileCommandsJson = this.replaceWorkspaceVars(compileCommandsJson);
         try {
             fs.statSync(compileCommandsJson);
-            log(DEBUG, "Using compileCommandsJson = '" + compileCommandsJson + "'.");
         }
         catch (err) {
             if (isDefault) {
@@ -311,13 +308,13 @@ class ConfigData {
                     let test = this.replaceWorkspaceVars("${workspaceFolder}/build/compile_commands.json");
                     fs.statSync(test);
                     compileCommandsJson = test;
-                    log(DEBUG, "Using alternative compileCommandsJson = '" + compileCommandsJson + "'.");
                 }
                 catch (err) {
                     // Ignore, caught later.
                 }
             }
         }
+        log(DEBUG, "Using compileCommandsJson = '" + compileCommandsJson + "'.");
         return compileCommandsJson;
     }
 


### PR DESCRIPTION
If `iwyu.compile_commands` is set to the default `auto`, then the extension will try:
  - `${workspaceFolder}/compile_commands.json`,
  - `${workspaceFolder}/build/compile_commands.json`,
  - `${fileWorkspaceFolder}/compile_commands.json`, and
  - `${fileWorkspaceFolder}/build/compile_commands.json`.

This should address https://github.com/helly25/vscode-iwyu/pull/5 in slightly better way as it supports the common places.

This fixes https://github.com/helly25/vscode-iwyu/issues/11