### PR TITLE
Rudimentary support for multi-root-workspaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,62 +1,66 @@
 # Change Log
 
+# [0.0.16]
+
+* Added rudimentary support for `${fileWorkspaceFolder}` in `iwyu.compile_commands` settings.
+
 # [0.0.15]
 
-Fixed https://github.com/helly25/vscode-iwyu/issues/2. When the `compile_commands.json` fiel cannot be found the extension would not be able to initialize.
-Fixed and issue with the actual setting name for the `compile_commands.json` file. The correct setting name is
+* Fixed https://github.com/helly25/vscode-iwyu/issues/2. When the `compile_commands.json` file cannot be found the extension would not be able to initialize.
+* Fixed and issue with the actual setting name for the `compile_commands.json` file. The correct setting name is
 `iwyu.compile_commands` as documented.
-Renamed settings `iwyu.diagnostics` to `iwyu.diagnostics.unused_includes`.
+* Renamed settings `iwyu.diagnostics` to `iwyu.diagnostics.unused_includes`.
 
 # [0.0.14]
 
-Fix include guard trigger.
-Refactor most extension code to use class Extension.
+* Fixed include guard trigger.
+* Refactored most extension code to use class Extension.
 
 # [0.0.13]
 
-Bad release
+Bad release!
 
 # [0.0.12]
 
-Update README.md.
+* Updated README.md.
 
 # [0.0.11]
 
-Only check `iwyu.diagnostics.include_guard` once per file.
-Fix lookup of setting `iwyu.diagnostics.include_guard`.
-Provide a direct link for diagnostics to the documentation.
+* Changed to only check `iwyu.diagnostics.include_guard` once per file.
+* Fixed lookup of setting `iwyu.diagnostics.include_guard`.
+* Provided a direct link for diagnostics to the documentation.
 
 # [0.0.10]
 
-Disable include guard checks by default. Seeting `iwyu.diagnostics.include_guard` to ".
+* Disabled include guard checks by default. Seeting `iwyu.diagnostics.include_guard` to ".
 
 # [0.0.9]
 
-Add support for include guard detection and correction.
-Add new settings:
-. `iwyu.diagnostics.include_guard_files`: `Regular expression for files that should be checked for include guards."
-. `iwyu.diagnostics.include_guard`: If this is non empty, then include guards are checked. The relative filename is denoted as '${file}' (as-is) or '${FILE}' (uppercase) , so in order to require include guards that end in a '_ thi must be set to '${file}_'.
+* Added support for include guard detection and correction.
+* Added new settings:
+  - `iwyu.diagnostics.include_guard_files`: `Regular expression for files that should be checked for include guards."
+  - `iwyu.diagnostics.include_guard`: If this is non empty, then include guards are checked. The relative filename is denoted as '${file}' (as-is) or '${FILE}' (uppercase) , so in order to require include guards that end in a '_ thi must be set to '${file}_'.
 
 # [0.0.8]
 
-Fix settings default for `iwyu.iwyu.keep`.
-Change default for `iwyu.diagnostics.iwyu_interval` to 5 (seconds).
+* Fixed settings default for `iwyu.iwyu.keep`.
+* Changed default for `iwyu.diagnostics.iwyu_interval` to 5 (seconds).
 
 # [0.0.7]
 
-Add new command `Include What You Use (all targets)`. See README.md for details.
+* Added new command `Include What You Use (all targets)`. See README.md for details.
 
 # [0.0.6]
 
-Added new config settings:
--  `iwyu.diagnostics.full_line_squiggles`: Whether to underline the whole line with squiggles or only the actual include part. The error is technically only on the actual include (from `#` to eiter `>` or second `"`) but tools commonly underline the whole line and the fix script will also remove the whole line.
-- Use LogOutputChannel instead of OutputChannel for better log output control.
-- Also remove setting `iwyu.debug`.
+* Added new config settings:
+  -  `iwyu.diagnostics.full_line_squiggles`: Whether to underline the whole line with squiggles or only the actual include part. The error is technically only on the actual include (from `#` to eiter `>` or second `"`) but tools commonly underline the whole line and the fix script will also remove the whole line.
+  - Use LogOutputChannel instead of OutputChannel for better log output control.
+  - Also removed setting `iwyu.debug`.
 
 # [0.0.5]
 
-- Per file IWYU data handling.
-- Improved header processing:
+* Fixed per file IWYU data handling.
+* Improved header processing:
     - Rename `iwyu.fix.safe` to `iwyu.fix.safe_headers` to match the actual argument name.
     - Change `iwyu.fix.safe_headers` to default to false, so that the tool works for headers by default.
     - Provide `--basedir` to `fix_includes.py` invocation to explicitly apply fixes only to the selected file.
@@ -66,8 +70,8 @@ Added new config settings:
 
 ## [0.0.4]
 
-- Speed up diagnostics by limiting how often iwyu is run and apply heuristics to early skip source scanning.
-- Add new config settings:
+* Sped up diagnostics by limiting how often iwyu is run and apply heuristics to early skip source scanning.
+* Added new config settings:
     - `iwyu.diagnostics.iwyu_interval`: Minimum interval time in seconds between iwyu calls.
     - `iwyu.diagnostics.only_re`: Only compute diagnostics for files that match this regexp.
     - `iwyu.diagnostics.scan_min`: Scan at least this many lines, if no include is found, then stop.
@@ -75,13 +79,13 @@ Added new config settings:
 
 ## [0.0.3]
 
-- Add diagnostic support
-- Add quickfix support
+* Added diagnostic support.
+* Added quickfix support.
 
 ## [0.0.2]
 
-- Fix image link
+* Fixed image link.
 
 ## [0.0.1]
 
-- Initial release
+* Initial release.

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -286,9 +286,11 @@ class ConfigData {
     }
 
     replaceWorkspaceVars(input: string): string {
-        return input.replace("${workspaceRoot}", this.workspacefolder)
-            .replace("${workspaceFolder}", this.workspacefolder);
-            // .replace("${fileWorkspaceFolder}", this.getXXXXXX);
+        input = input.replace("${workspaceRoot}", this.workspacefolder);
+        input = input.replace("${workspaceFolder}", this.workspacefolder);
+        let uri = vscode.window.activeTextEditor?.document?.uri;
+        input = input.replace("${fileWorkspaceFolder}", uri ? uri.fsPath : "");
+        return input;
     }
 
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -168,7 +168,7 @@ class CompileCommandsData {
                 this.compileCommands[fname] = new CompileCommand(entry, directory);
             }
         }
-        catch(err) {
+        catch (err) {
             let error = "Bad `iwyu.compile_commands` setting";
             log(ERROR, error + "'" + compileCommandsJson + "': " + err);
             vscode.window.showErrorMessage(error + ". Please check your settings and ensure the `compile_commands.json` file is in the specified location.<br/><br/>" + err);
@@ -285,11 +285,17 @@ class ConfigData {
         return this.compileCommandsData.compileCommands[fname] || null;
     }
 
-    compileCommandsJson(): string {
-        return this.config
-            .get("compile_commands", "${workspaceFolder}/XXX/compile_commands.json")
-            .replace("${workspaceRoot}", this.workspacefolder)
+    replaceWorkspaceVars(input: string): string {
+        return input.replace("${workspaceRoot}", this.workspacefolder)
             .replace("${workspaceFolder}", this.workspacefolder);
+            // .replace("${fileWorkspaceFolder}", this.getXXXXXX);
+    }
+
+
+    compileCommandsJson(): string {
+        let compileCommandsJsonDefault = "${workspaceFolder}/compile_commands.json";
+        let compileCommandsJson = this.config.get("compile_commands", compileCommandsJsonDefault);
+        return this.replaceWorkspaceVars(compileCommandsJson);
     }
 
     updateConfig() {
@@ -304,7 +310,7 @@ class ConfigData {
                 this.compileCommandsData = this.parseCompileCommands();
             }
         }
-        catch(err) {
+        catch (err) {
             log(ERROR, "Bad `iwyu.compile_commands` setting: '" + compileCommandsJson + "': " + err);
         }
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -293,7 +293,6 @@ class ConfigData {
         return input;
     }
 
-
     compileCommandsJson(): string {
         let compileCommandsJsonDefault = "${workspaceFolder}/compile_commands.json";
         let compileCommandsJson = this.config.get("compile_commands", compileCommandsJsonDefault);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -289,7 +289,8 @@ class ConfigData {
         input = input.replace("${workspaceRoot}", this.workspacefolder);
         input = input.replace("${workspaceFolder}", this.workspacefolder);
         let uri = vscode.window.activeTextEditor?.document?.uri;
-        input = input.replace("${fileWorkspaceFolder}", uri ? uri.fsPath : "");
+        let path = uri ? vscode.workspace.getWorkspaceFolder(uri)?.uri.fsPath : "";
+        input = input.replace("${fileWorkspaceFolder}", typeof path === "string" ? path : "");
         return input;
     }
 


### PR DESCRIPTION
* Add rudimentary support for `${fileWorkspaceFolder}` in `iwyu.compile_commands` settings.
