### PR TITLE
Fixed issue with iwyu.diagnostics.only_re

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+# [0.0.18]
+
+* Fixed issue with `iwyu.diagnostics.only_re` setting default (needs to be `""`).
+
 # [0.0.17]
 
 * Updated dependencies due to detected vulnerabilities.

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -740,6 +740,13 @@ class Extension {
         }
         this.configData.updateConfig();
         let diagnosticsOnlyRe: string = this.configData.config.get("diagnostics.only_re", "");
+        if (typeof diagnosticsOnlyRe  !== "string" || String(diagnosticsOnlyRe) === "true") {
+            // There was a bug fixed in https://github.com/helly25/vscode-iwyu/pull/4.
+            // This allows diagnostics to work in setups where defaults were copied into the user/workspace settings.
+            log(ERROR, "Bad value for setting `iwyu.diagnostics.only_re`, please update to `\"\"`.");
+            this.configData.config.update("diagnostics.only_re", undefined);
+            diagnosticsOnlyRe = "";
+        }
         if (diagnosticsOnlyRe && !doc.fileName.match(diagnosticsOnlyRe)) {
             return;
         }


### PR DESCRIPTION
Fixed issue with `iwyu.diagnostics.only_re` setting default (needs to be `""`), part 2.

If the defaults were saved with incorrect values, we need to ignore them.