### PR TITLE
Improve compile_commands.json handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 # [0.0.18]
 
 * Fixed issue with `iwyu.diagnostics.only_re` setting default (needs to be `""`).
+* Improved error handling for bad `iwyu.compile_commands` settings.
 
 # [0.0.17]
 


### PR DESCRIPTION
Improve compile_commands.json handling:
* Parse only if updated (filename or mtime).
* Improved error handling for bad `iwyu.compile_commands` settings.