### PR TITLE
Adds C to supported languages, implements logging for rejected languages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+# [0.0.19]
+
+* Added activation support for C language.
+
 # [0.0.18]
 
 * Fixed issue with `iwyu.diagnostics.only_re` setting default (needs to be `""`).

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "Include What You Use",
     "include-what-you-use"
   ],
-  "version": "0.0.18",
+  "version": "0.0.19",
   "publisher": "helly25",
   "license": "Apache-2.0",
   "repository": {
@@ -16,7 +16,7 @@
   },
   "icon": "images/logo.png",
   "engines": {
-    "vscode": "^1.78.0"
+    "vscode": "^1.92.0"
   },
   "categories": [
     "Other"

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "Other"
   ],
   "activationEvents": [
-    "onLanguage:cpp"
+    "onLanguage:cpp",
+    "onLanguage:c"
   ],
   "main": "./out/extension.js",
   "contributes": {


### PR DESCRIPTION
Small fixes to add activation on C code, as discussed in #23.
Functionality tested on:

- WSL Ubuntu 20.04.6 LTS
- include-what-you-use 0.24 (git:6e08906c) based on Ubuntu clang version 20.1.7 (++20250528073331+7cf14539b644-1~exp1~20250528193445.122
- VSCode Version 1.100.2

Passed Extension Test Suite in 41ms.