### PR TITLE
Expand workspace variables in include-what-you-use and mapping_file settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Added activation support for C language.
 * Added setting `iwyu.fix.fix_header` which fixes includes in the corresponding header for a given implementation file (e.g. foo.h when fixing foo.cpp).
+* Fixed https://github.com/helly25/vscode-iwyu/issues/32. `${workspaceFolder}`, `${workspaceRoot}` and `${fileWorkspaceFolder}` are now also expanded in the `iwyu.include-what-you-use` and `iwyu.iwyu.mapping_file` settings.
 
 # [0.0.18]
 

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ This extension has the following general settings:
   does not result in removing such headers, it merely prevents adding them, so it won't produce diagnostics for such includes.
 - `iwyu.fix_includes.py`: Path to the `fix_includes.py` script (finds the script on path if empty).
 - `iwyu.include-what-you-use`: Path to the `include-what-you-use` executable (finds the executable on path if empty).
+  Supports `${workspaceFolder}`, `${workspaceRoot}` and `${fileWorkspaceFolder}`.
 
 The diagnostics can be further configured:
 
@@ -82,7 +83,7 @@ The `include-what-you-use` tool can be configured with the following settings (n
 - `iwyu.iwyu.keep`: A glob that tells iwyu to always keep these includes. Can be provided multiple times.
 - `iwyu.iwyu.mapping_file`: Mapping file to use. See
    [IWYU Mappings](https://github.com/include-what-you-use/include-what-you-use/blob/master/docs/IWYUMappings.md) for
-   details.
+   details. Supports `${workspaceFolder}`, `${workspaceRoot}` and `${fileWorkspaceFolder}`.
 - `iwyu.iwyu.max_line_length`: Maximum line length for includes.Note that this only affects comments and alignment
    thereof, the maximum line length can still be exceeded with long file names
 - `iwyu.iwyu.no_default_mappings`: Do not add iwyu's default mappings.

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
         "iwyu.include-what-you-use": {
           "type": "string",
           "default": "include-what-you-use",
-          "description": "Path to the `include-what-you-use` executable."
+          "markdownDescription": "Path to the `include-what-you-use` executable. Supports `${workspaceFolder}`, `${workspaceRoot}` and `${fileWorkspaceFolder}`."
         },
         "iwyu.iwyu.additional_params": {
           "type": "string",
@@ -115,7 +115,7 @@
         "iwyu.iwyu.mapping_file": {
           "type": "string",
           "default": "",
-          "description": "Mapping file to use if any."
+          "markdownDescription": "Mapping file to use if any. Supports `${workspaceFolder}`, `${workspaceRoot}` and `${fileWorkspaceFolder}`."
         },
         "iwyu.iwyu.max_line_length": {
           "type": "integer",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -294,11 +294,11 @@ class ConfigData {
     }
 
     replaceWorkspaceVars(input: string): string {
-        input = input.replace("${workspaceRoot}", this.workspacefolder);
-        input = input.replace("${workspaceFolder}", this.workspacefolder);
+        input = input.split("${workspaceRoot}").join(this.workspacefolder);
+        input = input.split("${workspaceFolder}").join(this.workspacefolder);
         const uri = vscode.window.activeTextEditor?.document?.uri;
         const path = uri ? vscode.workspace.getWorkspaceFolder(uri)?.uri.fsPath : "";
-        input = input.replace("${fileWorkspaceFolder}", typeof path === "string" ? path : "");
+        input = input.split("${fileWorkspaceFolder}").join(typeof path === "string" ? path : "");
         return input;
     }
 
@@ -504,13 +504,13 @@ class Extension {
 
         const mapping = this.configData.config.get("iwyu.mapping_file", "").trim();
         if (mapping !== "") {
-            args.push("-Xiwyu --mapping_file=" + mapping);
+            args.push("-Xiwyu --mapping_file=" + this.configData.replaceWorkspaceVars(mapping));
         }
         const params = this.configData.config.get("iwyu.additional_params", "");
         if (params !== "") {
             args.push(params);
         }
-        let iwyu = this.configData.config.get("include-what-you-use", "include-what-you-use");
+        let iwyu = this.configData.replaceWorkspaceVars(this.configData.config.get("include-what-you-use", "include-what-you-use"));
         iwyu += " " + args.concat(compileCommand.arguments).join(" ") + " 2>&1";
 
         log(TRACE, "Directory: `" + compileCommand.directory + "`");


### PR DESCRIPTION
## Summary

Fixes #32.

`${workspaceFolder}`, `${workspaceRoot}` and `${fileWorkspaceFolder}` were only expanded for the `iwyu.compile_commands` setting. The `iwyu.include-what-you-use` and `iwyu.iwyu.mapping_file` settings were passed to the shell verbatim, so these variables were never substituted.

## Changes

- Apply `replaceWorkspaceVars` to the `iwyu.iwyu.mapping_file` and `iwyu.include-what-you-use` settings in `src/extension.ts`.
- Make `replaceWorkspaceVars` expand **all** occurrences rather than just the first (using `split`/`join` to stay ES2020-compatible).
- Document the supported variables for both settings in `package.json`, `README.md`, and `CHANGELOG.md`.

## Testing

- `npm run compile` passes. There are no existing unit tests covering `replaceWorkspaceVars`, so this was verified via the type checker only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)