### PR TITLE
Add test:local npm script for running tests from inside VS Code

### DIFF
--- a/package.json
+++ b/package.json
@@ -187,6 +187,7 @@
     "pretest": "npm run compile && npm run lint",
     "lint": "eslint src",
     "test": "node ./out/test/runTest.js",
+    "test:local": "env -u ELECTRON_RUN_AS_NODE -u VSCODE_IPC_HOOK -u VSCODE_PID npm test",
     "eslint": "eslint"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

Adds a `test:local` npm script that makes `npm test` runnable from VS Code's integrated terminal (and Claude Code).

## Why

When tests are launched from inside the VS Code extension host, `ELECTRON_RUN_AS_NODE=1` leaks into the shell environment. That forces the downloaded test copy of VS Code's Electron binary to run as **plain Node**, which then rejects every Electron/Chromium launch flag with `bad option: --no-sandbox` and aborts the run (exit code 9).

Unsetting `ELECTRON_RUN_AS_NODE` (plus the `VSCODE_IPC_HOOK`/`VSCODE_PID` vars, so the spawned instance doesn't try to attach to the running editor) lets the test instance launch cleanly:

```
  Extension Test Suite
    ✔ parseCommandLine test
    ✔ parseCommandLine test quotes
    ✔ parseCommandLine test escape
  3 passing
```

## Notes

- `env -u` is POSIX, so `test:local` targets macOS/Linux local runs.
- Plain `npm test` is unchanged and remains the cross-platform / CI entry point — the variable isn't set in CI, so it already works there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)