### PR TITLE
Remove redundant `?? []` on include-guard endif match

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -757,7 +757,7 @@ class Extension {
                 const lastLine: number = doc.lineCount - 1;
                 for (let line = lastLine; line > 0 && line > lastLine - 10; line--) {
                     const lineOfText = doc.lineAt(line);
-                    const match = [...lineOfText.text.matchAll(INC_GUARD_ENDIF)] ?? [];
+                    const match = [...lineOfText.text.matchAll(INC_GUARD_ENDIF)];
                     if (match.length === 0) {
                         continue;
                     }


### PR DESCRIPTION
## Summary

Fixes the diagnostic VS Code's TypeScript server reports on the include-guard endif scan:

> Right operand of `??` is unreachable because the left operand is never nullish.

[src/extension.ts:760](src/extension.ts#L760) spread the result of `matchAll(...)` and then applied `?? []`:

```ts
const match = [...lineOfText.text.matchAll(INC_GUARD_ENDIF)] ?? [];
```

A spread always yields an array, so it can never be `null`/`undefined` and the `?? []` was dead code. Removed it:

```ts
const match = [...lineOfText.text.matchAll(INC_GUARD_ENDIF)];
```

This also makes the line consistent with the other `matchAll` sites in the file (which only use `?? ""` to guard an *element access*, e.g. `[0]?.[2] ?? ""`).

## Notes

- This is a TS-server *hint*, not a compile or lint error — `tsc --noEmit` and `eslint` were already clean, which is why it wasn't caught by `npm run lint`.
- One-line change; no reformatting.

## Verification

`npm run compile` and `npm run lint` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)