### PR TITLE
Release 0.0.21

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Change Log
 
+# [0.0.21]
+
+* Updated dependencies to resolve security advisories in build/publish tooling
+  (transitive via `@vscode/vsce`): `form-data` (CRLF injection,
+  [GHSA-hmw2-7cc7-3qxx](https://github.com/advisories/GHSA-hmw2-7cc7-3qxx)),
+  `js-yaml` and `undici`. `npm audit` now reports no vulnerabilities. No changes
+  to the shipped extension behavior.
+
+# [0.0.20]
+
+* Added an optimized extension icon.
+* Fixed VSIX packaging and added tooling to publish releases to the VS Code
+  Marketplace, plus a cross-platform build/test CI matrix.
+* Updated dev dependencies and cleared all `npm audit` advisories.
+
 # [0.0.19]
 
 * Added activation support for C language.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "helly25iwyu",
-  "version": "0.0.20",
+  "version": "0.0.21",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "helly25iwyu",
-      "version": "0.0.20",
+      "version": "0.0.21",
       "license": "Apache-2.0",
       "devDependencies": {
         "@eslint/js": "^9.39.4",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "Include What You Use",
     "include-what-you-use"
   ],
-  "version": "0.0.20",
+  "version": "0.0.21",
   "publisher": "helly25",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
Release 0.0.21.

Bumps the version to `0.0.21` following the merge of #45, which resolved the
`form-data` CRLF injection advisory (GHSA-hmw2-7cc7-3qxx) and cleared the
`js-yaml` and `undici` advisories via `package.json` overrides.

This is a maintenance release: the affected packages are build/publish-time
transitive dependencies (via `@vscode/vsce`) only, so there is no change to the
shipped extension behavior. `npm audit` reports 0 vulnerabilities.

Also backfills the `CHANGELOG.md` entry for 0.0.20 (icon, VSIX packaging/publish
tooling, CI matrix, dependency updates).

Once merged, a GitHub Release `v0.0.21` will be published to trigger the
Marketplace publish workflow.