### PR TITLE
chore(deps): @types/node 26 + ES2022 target, raise VS Code minimum, drop unused deps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Change Log
 
+# [0.0.22]
+
+* **Raised the minimum supported VS Code version to 1.125.0** (was 1.92.0).
+  `@types/vscode` had already moved to 1.125, so the extension was being
+  compiled against APIs newer than the version it claimed to support; the
+  minimum now matches the types. Users on VS Code older than 1.125 should stay
+  on 0.0.21.
+* Updated dev dependencies (`eslint` 10, `@types/node` 26) and removed three
+  unused ones (`@eslint/js`, `globals`, `@types/glob`).
+* Raised the TypeScript `target`/`lib` to ES2022. The code already used ES2022
+  APIs (`Array.prototype.at`) and only compiled because older `@types/node`
+  declared them. No change to the shipped extension behavior.
+
 # [0.0.21]
 
 * Updated dependencies to resolve security advisories in build/publish tooling

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,24 +9,21 @@
       "version": "0.0.21",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@eslint/js": "^9.39.4",
-        "@types/glob": "^8.1.0",
         "@types/mocha": "^10.0.10",
-        "@types/node": "^22.19.19",
+        "@types/node": "^26.2.0",
         "@types/vscode": "^1.125.0",
         "@typescript-eslint/eslint-plugin": "^8.66.0",
         "@typescript-eslint/parser": "^8.66.0",
         "@vscode/test-electron": "^3.1.0",
         "@vscode/vsce": "^3.9.2",
-        "eslint": "^10.8.0",
+        "eslint": "^10.8.1",
         "glob": "^13.0.6",
-        "globals": "^17.9.0",
         "mocha": "^11.8.0",
         "typescript": "^5.9.3",
         "typescript-eslint": "^8.66.0"
       },
       "engines": {
-        "vscode": "^1.92.0"
+        "vscode": "^1.125.0"
       }
     },
     "node_modules/@azu/format-text": {
@@ -307,19 +304,6 @@
       },
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
-      }
-    },
-    "node_modules/@eslint/js": {
-      "version": "9.39.4",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.4.tgz",
-      "integrity": "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "url": "https://eslint.org/donate"
       }
     },
     "node_modules/@eslint/object-schema": {
@@ -791,28 +775,12 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/glob": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-8.1.0.tgz",
-      "integrity": "sha512-IO+MJPVhoqz+28h1qLAcBEH2+xHMK6MTyHJc7MTnnYb6wsoLR29POVGJ7LycmVXIqyy/4/2ShP5sUwTXuOwb/w==",
-      "dev": true,
-      "dependencies": {
-        "@types/minimatch": "^5.1.2",
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@types/minimatch": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-5.1.2.tgz",
-      "integrity": "sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==",
-      "dev": true
     },
     "node_modules/@types/mocha": {
       "version": "10.0.10",
@@ -822,13 +790,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.19.19",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.19.tgz",
-      "integrity": "sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==",
+      "version": "26.2.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.2.0.tgz",
+      "integrity": "sha512-5IviulTZeRNp2vAJ514cc/HUlY5nZ9fCbq9DMyC52BrhFZACo3nI0R7qBxhQmo/d27NFe96ur/b7Wwxklda+kg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.21.0"
+        "undici-types": "~8.3.0"
       }
     },
     "node_modules/@types/normalize-package-data": {
@@ -2335,9 +2303,9 @@
       }
     },
     "node_modules/eslint": {
-      "version": "10.8.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.8.0.tgz",
-      "integrity": "sha512-nuKKvN+oIBO0koN7Tm7dlkmnkc21mtt0QJLwAKzjLq14y6lRTdVG36MZHJ8eQHwdJMwZbQNMlPOYedMq/oVJvQ==",
+      "version": "10.8.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.8.1.tgz",
+      "integrity": "sha512-wqA7W2jbsC/BnV9Iv1UZpKVFkO1AdNoSmYW8NWG4HNOBbkAMvIqDZ27pI2f07dqn583NcIC44ckjAcOXDL1QbQ==",
       "dev": true,
       "license": "MIT",
       "workspaces": [
@@ -2869,19 +2837,6 @@
       },
       "engines": {
         "node": ">=10.13.0"
-      }
-    },
-    "node_modules/globals": {
-      "version": "17.9.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-17.9.0.tgz",
-      "integrity": "sha512-m/MvAW61QVU5VDNF1Vj8axt016h8w7L5TU1e9zlab7XIttAT2YAlCwl75K1fOqvMM9apmD7lbCIRhpfkhmxhCg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/globby": {
@@ -5709,9 +5664,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "icon": "images/icon.png",
   "engines": {
-    "vscode": "^1.92.0"
+    "vscode": "^1.125.0"
   },
   "categories": [
     "Other"
@@ -193,18 +193,15 @@
     "publish": "vsce publish"
   },
   "devDependencies": {
-    "@eslint/js": "^9.39.4",
-    "@types/glob": "^8.1.0",
     "@types/mocha": "^10.0.10",
-    "@types/node": "^22.19.19",
+    "@types/node": "^26.2.0",
     "@types/vscode": "^1.125.0",
     "@typescript-eslint/eslint-plugin": "^8.66.0",
     "@typescript-eslint/parser": "^8.66.0",
     "@vscode/test-electron": "^3.1.0",
     "@vscode/vsce": "^3.9.2",
-    "eslint": "^10.8.0",
+    "eslint": "^10.8.1",
     "glob": "^13.0.6",
-    "globals": "^17.9.0",
     "mocha": "^11.8.0",
     "typescript": "^5.9.3",
     "typescript-eslint": "^8.66.0"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,10 +1,10 @@
 {
   "compilerOptions": {
     "module": "commonjs",
-    "target": "ES2020",
+    "target": "ES2022",
     "outDir": "out",
     "lib": [
-      "ES2020"
+      "ES2022"
     ],
     "sourceMap": true,
     "rootDir": "src",


### PR DESCRIPTION
Carries the last remaining Dependabot PR (#56) plus the fixes it needed to be mergeable at all, and cleans up two things the recent bump wave exposed.

Rebased twice as #53 and #55 merged ahead of it; both are now in `main`, so only #56 is still superseded by this.

## What this changes vs `main`

| Change | Why |
|---|---|
| `@types/node` 22.19.19 → 26.2.0 | supersedes #56 (which targeted 26.1.2) |
| `tsconfig` `target`/`lib` ES2020 → ES2022 | required to make the above compile — see below |
| `engines.vscode` ^1.92.0 → ^1.125.0 | close the mismatch #52 introduced |
| drop `@eslint/js`, `globals`, `@types/glob` | unused |
| `eslint` ^10.8.0 → ^10.8.1 | incidental patch from the rebase |

## Why #56 could not merge on its own

`@types/node` 26 broke the build on:

```
src/extension.ts(944,65): error TS2339: Property 'at' does not exist on type 'readonly WorkspaceFolder[]'
```

This is not a bad bump. `Array.prototype.at` is **ES2022**, but `tsconfig.json` pinned `target`/`lib` to **ES2020**. It only ever compiled because older `@types/node` declared `.at()` globally, and 26 dropped that shim — so the bump exposed a latent misconfiguration rather than causing one. Raising `target`/`lib` to ES2022 is the actual fix. Safe: CI runs Node 22, and even VS Code 1.92 runs Node 20+.

## Minimum VS Code version: 1.92.0 → 1.125.0

⚠️ **User-facing change.** #52 bumped `@types/vscode` to `^1.125.0` while `engines.vscode` stayed at `^1.92.0`. The extension was therefore being type-checked against APIs 33 versions newer than the minimum it advertised, with nothing in CI capable of catching a resulting breakage for users on older VS Code.

The minimum now matches the types. Anyone on VS Code older than 1.125 should stay on 0.0.21.

Worth a follow-up decision: `@types/vscode` will keep outpacing `engines.vscode` on every future bump, and CI cannot catch the drift. An `ignore` rule for `@types/vscode` in `dependabot.yml` — moving it deliberately alongside `engines` — would prevent a repeat.

## Removed unused dependencies

`@eslint/js`, `globals`, and `@types/glob` have **zero references** anywhere outside `package.json` and the lockfile — `eslint.config.js` imports neither `@eslint/js` nor `globals`, and glob 13 ships its own type definitions, making `@types/glob` doubly redundant. Re-confirmed after #55 merged.

`globals` is therefore *removed* rather than updated, which supersedes the bump #55 just landed.

## Verification

Re-run on macOS after each rebase: `npm run compile`, `npm run lint`, the full integration suite (3 passing), and `pre-commit run --all-files` all pass. `npm audit` reports 0 vulnerabilities.

The `package.json` `version` field is deliberately left at 0.0.21 — per this repo's convention the version bump lands in a separate `Release 0.0.22` PR, so only the CHANGELOG heading is added here.