### PR TITLE
chore(dependabot): pin @types/vscode to engines.vscode

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,9 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 5
+    ignore:
+      # Must match `engines.vscode`; bump both together by hand.
+      - dependency-name: "@types/vscode"
     groups:
       # Everything here is a devDependency, so a single grouped PR keeps the
       # review load low and CI runs once per batch.


### PR DESCRIPTION
`@types/vscode` describes the API surface of a specific VS Code release, so it must track `engines.vscode` (the oldest editor we support), not the newest release.

Bumped on its own it widens the typed API surface past that floor, and no CI job can catch the result — the build stays green while the extension breaks only for users on an older editor. That is what happened in #52 (types → 1.125, `engines` left at 1.92), which #57 then had to reconcile.

Ignoring it here means both move together, by hand, when the supported floor is deliberately raised.

One tradeoff: ignore conditions apply to security updates too, so Dependabot will no longer propose those for this package. Acceptable for a types-only package that ships no runtime code.