### PR TITLE
Release 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,17 +1,24 @@
 # Change Log
 
-# [0.0.22]
+# [1.0.0]
 
-* **Raised the minimum supported VS Code version to 1.125.0** (was 1.92.0).
-  `@types/vscode` had already moved to 1.125, so the extension was being
-  compiled against APIs newer than the version it claimed to support; the
-  minimum now matches the types. Users on VS Code older than 1.125 should stay
-  on 0.0.21.
-* Updated dev dependencies (`eslint` 10, `@types/node` 26) and removed three
-  unused ones (`@eslint/js`, `globals`, `@types/glob`).
-* Raised the TypeScript `target`/`lib` to ES2022. The code already used ES2022
-  APIs (`Array.prototype.at`) and only compiled because older `@types/node`
-  declared them. No change to the shipped extension behavior.
+First stable release. The `iwyu.*` settings are now considered stable;
+incompatible changes to them will come with a major version bump.
+
+* **Raised the minimum supported VS Code version to 1.125.0** (was 1.92.0). The
+  extension was already being compiled against 1.125 APIs while claiming to
+  support 1.92. Users on older VS Code should stay on 0.0.21.
+* Fixed the declared default of `iwyu.diagnostics.full_line_squiggles`, which
+  was the string `"true"` for a boolean setting. Behavior is unchanged.
+* Updated dependencies to resolve security advisories in build/publish tooling:
+  `brace-expansion`, `fast-uri`, `js-yaml` and `undici`. `npm audit` now reports
+  no vulnerabilities.
+* Fixed the macOS CI job, broken by VS Code renaming its macOS executable
+  (`@vscode/test-electron` 3.x), and moved CI to Node 22.
+* Updated dev dependencies, removed three unused ones (`@eslint/js`, `globals`,
+  `@types/glob`), and raised the TypeScript `target`/`lib` to ES2022.
+
+Apart from the minimum version, no changes to the shipped extension behavior.
 
 # [0.0.21]
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "helly25iwyu",
-  "version": "0.0.21",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "helly25iwyu",
-      "version": "0.0.21",
+      "version": "1.0.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/mocha": "^10.0.10",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "Include What You Use",
     "include-what-you-use"
   ],
-  "version": "0.0.21",
+  "version": "1.0.0",
   "publisher": "helly25",
   "license": "Apache-2.0",
   "repository": {
@@ -57,7 +57,7 @@
         },
         "iwyu.diagnostics.full_line_squiggles": {
           "type": "boolean",
-          "default": "true",
+          "default": true,
           "description": "Whether to underline the whole line with squiggles or only the actual include part."
         },
         "iwyu.diagnostics.include_guard_files": {


### PR DESCRIPTION
First stable release.

⚠️ **Raises the minimum VS Code version from 1.92.0 to 1.125.0** — drops support for older editors. Users on older VS Code stay on 0.0.21; the Marketplace handles that via `engines`.

Going straight to 1.0.0 rather than 0.9.0: no incompatible changes are planned, and the settings are staying as they are, so 0.9.0 would only be a version to pass through and decide about again.

Also fixes `iwyu.diagnostics.full_line_squiggles`, whose declared default was the string `"true"` for a `"type": "boolean"` setting. Harmless in practice — it is truthy, and `extension.ts:740` passes its own `true` fallback — but wrong in the schema, and worth correcting before declaring the settings stable. No behavior change.

The 27 `iwyu.*` setting names are unchanged and now stable. The known cosmetic warts (`iwyu.iwyu.*` stutter, `iwyu.fix_includes.py` inventing a hierarchy level, `iwyu.include-what-you-use` being the lone kebab-case key) are deliberately kept: renaming would break existing `settings.json` files and require deprecation aliases carried for years, buying only tidiness.

Verified locally: compile, lint, integration suite (3 passing), `npm audit` (0 vulnerabilities), pre-commit, and `npm run package` produces a valid VSIX.

Note the branch is still named `release/0.0.22` — a PR's head branch cannot be renamed without opening a new PR, and it disappears on merge.

Publishing the GitHub Release with tag `1.0.0` after merge triggers the Marketplace publish — I have not done that.